### PR TITLE
fixed dotfetch

### DIFF
--- a/small/dotfetch.conf
+++ b/small/dotfetch.conf
@@ -1,7 +1,7 @@
 # https://github.com/chick2d/neofetch-themes
 # Made by https://github.com/chatsagnik
 
-{
+print_info() {
     prin " "
     info "$(color 1) OS  " distro
     info "$(color 2) VER" kernel


### PR DESCRIPTION
`print_info()` is missing in the `small/dotfetch.conf` theme