### PR TITLE
hfetch-nt (or the hfetch neofetch theme variant)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Fun fact: This is called af++ or AxylFetch++ because this was actually based on 
 
 [hfetch-nt](https://github.com/Chick2D/neofetch-themes/blob/main/small/hfetch-nt.conf)
 ---
-![](https://user-images.githubusercontent.com/119129086/205439388-113f217b-6291-495b-89e4-bfd1f2dfbb9e.png)
+![](https://user-images.githubusercontent.com/119129086/205440325-9b147b81-9431-4498-a141-d8ceabb5bca6.png)
 
 ### [FAQs](https://github.com/Chick2D/neofetch-themes/wiki/FAQs)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,12 @@ Fun fact: This is called af++ or AxylFetch++ because this was actually based on 
 ---
 ![](https://github.com/TanbinIslam43/mydotfiles/blob/main/.config/neofetch/screenshot.png)
 
+[hfetch-nt](https://github.com/Chick2D/neofetch-themes/blob/main/small/hfetch-nt.conf)
+---
+![](https://user-images.githubusercontent.com/119129086/205439388-113f217b-6291-495b-89e4-bfd1f2dfbb9e.png)
+
 ### [FAQs](https://github.com/Chick2D/neofetch-themes/wiki/FAQs)
+
 
 ### Installation 
 ---

--- a/small/hfetch-nt.conf
+++ b/small/hfetch-nt.conf
@@ -10,9 +10,10 @@ print_info() {
     info "-> Terminal" term
     info "-> Memory" memory
     info "-> Disk" disk
-    info "-> Locale" locale  # This only works on glibc systems.
-
-    info cols
+    info "-> Locale" locale
+    echo " "
+    echo -e "                 \e[0;37m \e[0m\e[0;31m \e[0m\e[0;33m \e[0m\e[0;32m \e[0m\e[0;36m \e[0m\e[0;35m \e[0m\e[0;30m \e[0m"
+    echo " "
 }
 
 # Kernel

--- a/small/hfetch-nt.conf
+++ b/small/hfetch-nt.conf
@@ -15,17 +15,6 @@ print_info() {
     info cols
 }
 
-# Title
-
-
-# Hide/Show Fully qualified domain name.
-#
-# Default:  'off'
-# Values:   'on', 'off'
-# Flag:     --title_fqdn
-title_fqdn="off"
-
-
 # Kernel
 
 
@@ -108,23 +97,6 @@ memory_percent="off"
 # gib: ' 0.98GiB / 6.79GiB'
 memory_unit="mib"
 
-
-# Packages
-
-
-# Show/Hide Package Manager names.
-#
-# Default: 'tiny'
-# Values:  'on', 'tiny' 'off'
-# Flag:    --package_managers
-#
-# Example:
-# on:   '998 (pacman), 8 (flatpak), 4 (snap)'
-# tiny: '908 (pacman, flatpak, snap)'
-# off:  '908'
-package_managers="on"
-
-
 # Shell
 
 
@@ -150,173 +122,6 @@ shell_path="off"
 # off: 'bash'
 shell_version="on"
 
-
-# CPU
-
-
-# CPU speed type
-#
-# Default: 'bios_limit'
-# Values: 'scaling_cur_freq', 'scaling_min_freq', 'scaling_max_freq', 'bios_limit'.
-# Flag:    --speed_type
-# Supports: Linux with 'cpufreq'
-# NOTE: Any file in '/sys/devices/system/cpu/cpu0/cpufreq' can be used as a value.
-speed_type="bios_limit"
-
-# CPU speed shorthand
-#
-# Default: 'off'
-# Values: 'on', 'off'.
-# Flag:    --speed_shorthand
-# NOTE: This flag is not supported in systems with CPU speed less than 1 GHz
-#
-# Example:
-# on:    'i7-6500U (4) @ 3.1GHz'
-# off:   'i7-6500U (4) @ 3.100GHz'
-speed_shorthand="off"
-
-# Enable/Disable CPU brand in output.
-#
-# Default: 'on'
-# Values:  'on', 'off'
-# Flag:    --cpu_brand
-#
-# Example:
-# on:   'Intel i7-6500U'
-# off:  'i7-6500U (4)'
-cpu_brand="on"
-
-# CPU Speed
-# Hide/Show CPU speed.
-#
-# Default: 'on'
-# Values:  'on', 'off'
-# Flag:    --cpu_speed
-#
-# Example:
-# on:  'Intel i7-6500U (4) @ 3.1GHz'
-# off: 'Intel i7-6500U (4)'
-cpu_speed="on"
-
-# CPU Cores
-# Display CPU cores in output
-#
-# Default: 'logical'
-# Values:  'logical', 'physical', 'off'
-# Flag:    --cpu_cores
-# Support: 'physical' doesn't work on BSD.
-#
-# Example:
-# logical:  'Intel i7-6500U (4) @ 3.1GHz' (All virtual cores)
-# physical: 'Intel i7-6500U (2) @ 3.1GHz' (All physical cores)
-# off:      'Intel i7-6500U @ 3.1GHz'
-cpu_cores="logical"
-
-# CPU Temperature
-# Hide/Show CPU temperature.
-# Note the temperature is added to the regular CPU function.
-#
-# Default: 'off'
-# Values:  'C', 'F', 'off'
-# Flag:    --cpu_temp
-# Supports: Linux, BSD
-# NOTE: For FreeBSD and NetBSD-based systems, you'll need to enable
-#       coretemp kernel module. This only supports newer Intel processors.
-#
-# Example:
-# C:   'Intel i7-6500U (4) @ 3.1GHz [27.2°C]'
-# F:   'Intel i7-6500U (4) @ 3.1GHz [82.0°F]'
-# off: 'Intel i7-6500U (4) @ 3.1GHz'
-cpu_temp="off"
-
-
-# GPU
-
-
-# Enable/Disable GPU Brand
-#
-# Default: 'on'
-# Values:  'on', 'off'
-# Flag:    --gpu_brand
-#
-# Example:
-# on:  'AMD HD 7950'
-# off: 'HD 7950'
-gpu_brand="on"
-
-# Which GPU to display
-#
-# Default: 'all'
-# Values:  'all', 'dedicated', 'integrated'
-# Flag:    --gpu_type
-# Supports: Linux
-#
-# Example:
-# all:
-#   GPU1: AMD HD 7950
-#   GPU2: Intel Integrated Graphics
-#
-# dedicated:
-#   GPU1: AMD HD 7950
-#
-# integrated:
-#   GPU1: Intel Integrated Graphics
-gpu_type="all"
-
-
-# Resolution
-
-
-# Display refresh rate next to each monitor
-# Default: 'off'
-# Values:  'on', 'off'
-# Flag:    --refresh_rate
-# Supports: Doesn't work on Windows.
-#
-# Example:
-# on:  '1920x1080 @ 60Hz'
-# off: '1920x1080'
-refresh_rate="off"
-
-
-# Gtk Theme / Icons / Font
-
-
-# Shorten output of GTK Theme / Icons / Font
-#
-# Default: 'off'
-# Values:  'on', 'off'
-# Flag:    --gtk_shorthand
-#
-# Example:
-# on:  'Numix, Adwaita'
-# off: 'Numix [GTK2], Adwaita [GTK3]'
-gtk_shorthand="off"
-
-
-# Enable/Disable gtk2 Theme / Icons / Font
-#
-# Default: 'on'
-# Values:  'on', 'off'
-# Flag:    --gtk2
-#
-# Example:
-# on:  'Numix [GTK2], Adwaita [GTK3]'
-# off: 'Adwaita [GTK3]'
-gtk2="on"
-
-# Enable/Disable gtk3 Theme / Icons / Font
-#
-# Default: 'on'
-# Values:  'on', 'off'
-# Flag:    --gtk3
-#
-# Example:
-# on:  'Numix [GTK2], Adwaita [GTK3]'
-# off: 'Numix [GTK2]'
-gtk3="on"
-
-
 # IP Address
 
 
@@ -334,16 +139,6 @@ public_ip_host="http://ident.me"
 # Flag:    --ip_timeout
 public_ip_timeout=2
 
-
-# Desktop Environment
-
-
-# Show Desktop Environment version
-#
-# Default: 'on'
-# Values:  'on', 'off'
-# Flag:    --de_version
-de_version="on"
 
 
 # Disk
@@ -403,60 +198,6 @@ disk_subtitle="mount"
 # off: 'Disk (/): 74G / 118G'
 disk_percent="on"
 
-
-# Song
-
-
-# Manually specify a music player.
-#
-# Default: 'auto'
-# Values:  'auto', 'player-name'
-# Flag:    --music_player
-#
-# Available values for 'player-name':
-#
-# amarok
-# audacious
-# banshee
-# bluemindo
-# clementine
-# cmus
-# deadbeef
-# deepin-music
-# dragon
-# elisa
-# exaile
-# gnome-music
-# gmusicbrowser
-# gogglesmm
-# guayadeque
-# io.elementary.music
-# iTunes
-# juk
-# lollypop
-# mocp
-# mopidy
-# mpd
-# muine
-# netease-cloud-music
-# olivia
-# playerctl
-# pogo
-# pragha
-# qmmp
-# quodlibet
-# rhythmbox
-# sayonara
-# smplayer
-# spotify
-# strawberry
-# tauonmb
-# tomahawk
-# vlc
-# xmms2d
-# xnoise
-# yarock
-music_player="auto"
 
 # Format to display song information.
 #
@@ -657,9 +398,7 @@ bar_color_total="distro"
 # infobar: 'info [---=======]'
 # barinfo: '[---=======] info'
 # off:     'info'
-cpu_display="off"
 memory_display="on"
-battery_display="off"
 disk_display="on"
 
 
@@ -758,79 +497,6 @@ ascii_colors=(distro)
 # Values:  'on', 'off'
 # Flag:    --ascii_bold
 ascii_bold="on"
-
-
-# Image Options
-
-
-# Image loop
-# Setting this to on will make neofetch redraw the image constantly until
-# Ctrl+C is pressed. This fixes display issues in some terminal emulators.
-#
-# Default:  'off'
-# Values:   'on', 'off'
-# Flag:     --loop
-image_loop="off"
-
-# Thumbnail directory
-#
-# Default: '~/.cache/thumbnails/neofetch'
-# Values:  'dir'
-thumbnail_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/thumbnails/neofetch"
-
-# Crop mode
-#
-# Default:  'normal'
-# Values:   'normal', 'fit', 'fill'
-# Flag:     --crop_mode
-#
-# See this wiki page to learn about the fit and fill options.
-# https://github.com/dylanaraps/neofetch/wiki/What-is-Waifu-Crop%3F
-crop_mode="normal"
-
-# Crop offset
-# Note: Only affects 'normal' crop mode.
-#
-# Default:  'center'
-# Values:   'northwest', 'north', 'northeast', 'west', 'center'
-#           'east', 'southwest', 'south', 'southeast'
-# Flag:     --crop_offset
-crop_offset="center"
-
-# Image size
-# The image is half the terminal width by default.
-#
-# Default: 'auto'
-# Values:  'auto', '00px', '00%', 'none'
-# Flags:   --image_size
-#          --size
-image_size="auto"
-
-# Gap between image and text
-#
-# Default: '3'
-# Values:  'num', '-num'
-# Flag:    --gap
-gap=3
-
-# Image offsets
-# Only works with the w3m backend.
-#
-# Default: '0'
-# Values:  'px'
-# Flags:   --xoffset
-#          --yoffset
-yoffset=0
-xoffset=0
-
-# Image background color
-# Only works with the w3m backend.
-#
-# Default: ''
-# Values:  'color', 'blue'
-# Flag:    --bg_color
-background_color=
-
 
 # Misc Options
 

--- a/small/hfetch-nt.conf
+++ b/small/hfetch-nt.conf
@@ -1,0 +1,863 @@
+# See this wiki page for more info:
+# https://github.com/dylanaraps/neofetch/wiki/Customizing-Info
+echo " "
+print_info() {
+    info "->" title
+    info "-> OS" distro
+    #info "Host" model
+    info "-> Kernel" kernel
+    info "-> Uptime" uptime
+    #info "Packages" packages
+    info "-> Shell" shell
+    #info "Resolution" resolution
+    #info "DE" de
+    #info "WM" wm
+    #info "WM Theme" wm_theme
+    #info "Theme" theme
+    #info "Icons" icons
+    info "-> Terminal" term
+    #info "Terminal Font" term_font
+    #info "CPU" cpu
+    #info "GPU" gpu
+    info "-> Memory" memory
+
+    # info "GPU Driver" gpu_driver  # Linux/macOS only
+    # info "CPU Usage" cpu_usage
+    info "-> Disk" disk
+    # info "Battery" battery
+    # info "Font" font
+    # info "Song" song
+    # [[ "$player" ]] && prin "Music Player" "$player"
+    # info "Local IP" local_ip
+    # info "Public IP" public_ip
+    # info "Users" users
+    info "-> Locale" locale  # This only works on glibc systems.
+
+    info cols
+}
+
+# Title
+
+
+# Hide/Show Fully qualified domain name.
+#
+# Default:  'off'
+# Values:   'on', 'off'
+# Flag:     --title_fqdn
+title_fqdn="off"
+
+
+# Kernel
+
+
+# Shorten the output of the kernel function.
+#
+# Default:  'on'
+# Values:   'on', 'off'
+# Flag:     --kernel_shorthand
+# Supports: Everything except *BSDs (except PacBSD and PC-BSD)
+#
+# Example:
+# on:  '4.8.9-1-ARCH'
+# off: 'Linux 4.8.9-1-ARCH'
+kernel_shorthand="on"
+
+
+# Distro
+
+
+# Shorten the output of the distro function
+#
+# Default:  'off'
+# Values:   'on', 'tiny', 'off'
+# Flag:     --distro_shorthand
+# Supports: Everything except Windows and Haiku
+distro_shorthand="off"
+
+# Show/Hide OS Architecture.
+# Show 'x86_64', 'x86' and etc in 'Distro:' output.
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --os_arch
+#
+# Example:
+# on:  'Arch Linux x86_64'
+# off: 'Arch Linux'
+os_arch="on"
+
+
+# Uptime
+
+
+# Shorten the output of the uptime function
+#
+# Default: 'on'
+# Values:  'on', 'tiny', 'off'
+# Flag:    --uptime_shorthand
+#
+# Example:
+# on:   '2 days, 10 hours, 3 mins'
+# tiny: '2d 10h 3m'
+# off:  '2 days, 10 hours, 3 minutes'
+uptime_shorthand="on"
+
+
+# Memory
+
+
+# Show memory pecentage in output.
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --memory_percent
+#
+# Example:
+# on:   '1801MiB / 7881MiB (22%)'
+# off:  '1801MiB / 7881MiB'
+memory_percent="off"
+
+# Change memory output unit.
+#
+# Default: 'mib'
+# Values:  'kib', 'mib', 'gib'
+# Flag:    --memory_unit
+#
+# Example:
+# kib  '1020928KiB / 7117824KiB'
+# mib  '1042MiB / 6951MiB'
+# gib: ' 0.98GiB / 6.79GiB'
+memory_unit="mib"
+
+
+# Packages
+
+
+# Show/Hide Package Manager names.
+#
+# Default: 'tiny'
+# Values:  'on', 'tiny' 'off'
+# Flag:    --package_managers
+#
+# Example:
+# on:   '998 (pacman), 8 (flatpak), 4 (snap)'
+# tiny: '908 (pacman, flatpak, snap)'
+# off:  '908'
+package_managers="on"
+
+
+# Shell
+
+
+# Show the path to $SHELL
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --shell_path
+#
+# Example:
+# on:  '/bin/bash'
+# off: 'bash'
+shell_path="off"
+
+# Show $SHELL version
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --shell_version
+#
+# Example:
+# on:  'bash 4.4.5'
+# off: 'bash'
+shell_version="on"
+
+
+# CPU
+
+
+# CPU speed type
+#
+# Default: 'bios_limit'
+# Values: 'scaling_cur_freq', 'scaling_min_freq', 'scaling_max_freq', 'bios_limit'.
+# Flag:    --speed_type
+# Supports: Linux with 'cpufreq'
+# NOTE: Any file in '/sys/devices/system/cpu/cpu0/cpufreq' can be used as a value.
+speed_type="bios_limit"
+
+# CPU speed shorthand
+#
+# Default: 'off'
+# Values: 'on', 'off'.
+# Flag:    --speed_shorthand
+# NOTE: This flag is not supported in systems with CPU speed less than 1 GHz
+#
+# Example:
+# on:    'i7-6500U (4) @ 3.1GHz'
+# off:   'i7-6500U (4) @ 3.100GHz'
+speed_shorthand="off"
+
+# Enable/Disable CPU brand in output.
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --cpu_brand
+#
+# Example:
+# on:   'Intel i7-6500U'
+# off:  'i7-6500U (4)'
+cpu_brand="on"
+
+# CPU Speed
+# Hide/Show CPU speed.
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --cpu_speed
+#
+# Example:
+# on:  'Intel i7-6500U (4) @ 3.1GHz'
+# off: 'Intel i7-6500U (4)'
+cpu_speed="on"
+
+# CPU Cores
+# Display CPU cores in output
+#
+# Default: 'logical'
+# Values:  'logical', 'physical', 'off'
+# Flag:    --cpu_cores
+# Support: 'physical' doesn't work on BSD.
+#
+# Example:
+# logical:  'Intel i7-6500U (4) @ 3.1GHz' (All virtual cores)
+# physical: 'Intel i7-6500U (2) @ 3.1GHz' (All physical cores)
+# off:      'Intel i7-6500U @ 3.1GHz'
+cpu_cores="logical"
+
+# CPU Temperature
+# Hide/Show CPU temperature.
+# Note the temperature is added to the regular CPU function.
+#
+# Default: 'off'
+# Values:  'C', 'F', 'off'
+# Flag:    --cpu_temp
+# Supports: Linux, BSD
+# NOTE: For FreeBSD and NetBSD-based systems, you'll need to enable
+#       coretemp kernel module. This only supports newer Intel processors.
+#
+# Example:
+# C:   'Intel i7-6500U (4) @ 3.1GHz [27.2°C]'
+# F:   'Intel i7-6500U (4) @ 3.1GHz [82.0°F]'
+# off: 'Intel i7-6500U (4) @ 3.1GHz'
+cpu_temp="off"
+
+
+# GPU
+
+
+# Enable/Disable GPU Brand
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --gpu_brand
+#
+# Example:
+# on:  'AMD HD 7950'
+# off: 'HD 7950'
+gpu_brand="on"
+
+# Which GPU to display
+#
+# Default: 'all'
+# Values:  'all', 'dedicated', 'integrated'
+# Flag:    --gpu_type
+# Supports: Linux
+#
+# Example:
+# all:
+#   GPU1: AMD HD 7950
+#   GPU2: Intel Integrated Graphics
+#
+# dedicated:
+#   GPU1: AMD HD 7950
+#
+# integrated:
+#   GPU1: Intel Integrated Graphics
+gpu_type="all"
+
+
+# Resolution
+
+
+# Display refresh rate next to each monitor
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --refresh_rate
+# Supports: Doesn't work on Windows.
+#
+# Example:
+# on:  '1920x1080 @ 60Hz'
+# off: '1920x1080'
+refresh_rate="off"
+
+
+# Gtk Theme / Icons / Font
+
+
+# Shorten output of GTK Theme / Icons / Font
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --gtk_shorthand
+#
+# Example:
+# on:  'Numix, Adwaita'
+# off: 'Numix [GTK2], Adwaita [GTK3]'
+gtk_shorthand="off"
+
+
+# Enable/Disable gtk2 Theme / Icons / Font
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --gtk2
+#
+# Example:
+# on:  'Numix [GTK2], Adwaita [GTK3]'
+# off: 'Adwaita [GTK3]'
+gtk2="on"
+
+# Enable/Disable gtk3 Theme / Icons / Font
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --gtk3
+#
+# Example:
+# on:  'Numix [GTK2], Adwaita [GTK3]'
+# off: 'Numix [GTK2]'
+gtk3="on"
+
+
+# IP Address
+
+
+# Website to ping for the public IP
+#
+# Default: 'http://ident.me'
+# Values:  'url'
+# Flag:    --ip_host
+public_ip_host="http://ident.me"
+
+# Public IP timeout.
+#
+# Default: '2'
+# Values:  'int'
+# Flag:    --ip_timeout
+public_ip_timeout=2
+
+
+# Desktop Environment
+
+
+# Show Desktop Environment version
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --de_version
+de_version="on"
+
+
+# Disk
+
+
+# Which disks to display.
+# The values can be any /dev/sdXX, mount point or directory.
+# NOTE: By default we only show the disk info for '/'.
+#
+# Default: '/'
+# Values:  '/', '/dev/sdXX', '/path/to/drive'.
+# Flag:    --disk_show
+#
+# Example:
+# disk_show=('/' '/dev/sdb1'):
+#      'Disk (/): 74G / 118G (66%)'
+#      'Disk (/mnt/Videos): 823G / 893G (93%)'
+#
+# disk_show=('/'):
+#      'Disk (/): 74G / 118G (66%)'
+#
+disk_show=('/')
+
+# Disk subtitle.
+# What to append to the Disk subtitle.
+#
+# Default: 'mount'
+# Values:  'mount', 'name', 'dir', 'none'
+# Flag:    --disk_subtitle
+#
+# Example:
+# name:   'Disk (/dev/sda1): 74G / 118G (66%)'
+#         'Disk (/dev/sdb2): 74G / 118G (66%)'
+#
+# mount:  'Disk (/): 74G / 118G (66%)'
+#         'Disk (/mnt/Local Disk): 74G / 118G (66%)'
+#         'Disk (/mnt/Videos): 74G / 118G (66%)'
+#
+# dir:    'Disk (/): 74G / 118G (66%)'
+#         'Disk (Local Disk): 74G / 118G (66%)'
+#         'Disk (Videos): 74G / 118G (66%)'
+#
+# none:   'Disk: 74G / 118G (66%)'
+#         'Disk: 74G / 118G (66%)'
+#         'Disk: 74G / 118G (66%)'
+disk_subtitle="mount"
+
+# Disk percent.
+# Show/Hide disk percent.
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --disk_percent
+#
+# Example:
+# on:  'Disk (/): 74G / 118G (66%)'
+# off: 'Disk (/): 74G / 118G'
+disk_percent="on"
+
+
+# Song
+
+
+# Manually specify a music player.
+#
+# Default: 'auto'
+# Values:  'auto', 'player-name'
+# Flag:    --music_player
+#
+# Available values for 'player-name':
+#
+# amarok
+# audacious
+# banshee
+# bluemindo
+# clementine
+# cmus
+# deadbeef
+# deepin-music
+# dragon
+# elisa
+# exaile
+# gnome-music
+# gmusicbrowser
+# gogglesmm
+# guayadeque
+# io.elementary.music
+# iTunes
+# juk
+# lollypop
+# mocp
+# mopidy
+# mpd
+# muine
+# netease-cloud-music
+# olivia
+# playerctl
+# pogo
+# pragha
+# qmmp
+# quodlibet
+# rhythmbox
+# sayonara
+# smplayer
+# spotify
+# strawberry
+# tauonmb
+# tomahawk
+# vlc
+# xmms2d
+# xnoise
+# yarock
+music_player="auto"
+
+# Format to display song information.
+#
+# Default: '%artist% - %album% - %title%'
+# Values:  '%artist%', '%album%', '%title%'
+# Flag:    --song_format
+#
+# Example:
+# default: 'Song: Jet - Get Born - Sgt Major'
+song_format="%artist% - %album% - %title%"
+
+# Print the Artist, Album and Title on separate lines
+#
+# Default: 'off'
+# Values:  'on', 'off'
+# Flag:    --song_shorthand
+#
+# Example:
+# on:  'Artist: The Fratellis'
+#      'Album: Costello Music'
+#      'Song: Chelsea Dagger'
+#
+# off: 'Song: The Fratellis - Costello Music - Chelsea Dagger'
+song_shorthand="off"
+
+# 'mpc' arguments (specify a host, password etc).
+#
+# Default:  ''
+# Example: mpc_args=(-h HOST -P PASSWORD)
+mpc_args=()
+
+
+# Text Colors
+
+
+# Text Colors
+#
+# Default:  'distro'
+# Values:   'distro', 'num' 'num' 'num' 'num' 'num' 'num'
+# Flag:     --colors
+#
+# Each number represents a different part of the text in
+# this order: 'title', '@', 'underline', 'subtitle', 'colon', 'info'
+#
+# Example:
+# colors=(distro)      - Text is colored based on Distro colors.
+# colors=(4 6 1 8 8 6) - Text is colored in the order above.
+colors=(distro)
+
+
+# Text Options
+
+
+# Toggle bold text
+#
+# Default:  'on'
+# Values:   'on', 'off'
+# Flag:     --bold
+bold="on"
+
+# Enable/Disable Underline
+#
+# Default:  'on'
+# Values:   'on', 'off'
+# Flag:     --underline
+underline_enabled="on"
+
+# Underline character
+#
+# Default:  '-'
+# Values:   'string'
+# Flag:     --underline_char
+underline_char="-"
+
+
+# Info Separator
+# Replace the default separator with the specified string.
+#
+# Default:  ':'
+# Flag:     --separator
+#
+# Example:
+# separator="->":   'Shell-> bash'
+# separator=" =":   'WM = dwm'
+separator=":"
+
+
+# Color Blocks
+
+
+# Color block range
+# The range of colors to print.
+#
+# Default:  '0', '15'
+# Values:   'num'
+# Flag:     --block_range
+#
+# Example:
+#
+# Display colors 0-7 in the blocks.  (8 colors)
+# neofetch --block_range 0 7
+#
+# Display colors 0-15 in the blocks. (16 colors)
+# neofetch --block_range 0 15
+block_range=(0 7)
+
+# Toggle color blocks
+#
+# Default:  'on'
+# Values:   'on', 'off'
+# Flag:     --color_blocks
+color_blocks="on"
+
+# Color block width in spaces
+#
+# Default:  '3'
+# Values:   'num'
+# Flag:     --block_width
+block_width=3
+
+# Color block height in lines
+#
+# Default:  '1'
+# Values:   'num'
+# Flag:     --block_height
+block_height=1
+
+# Color Alignment
+#
+# Default: 'auto'
+# Values: 'auto', 'num'
+# Flag: --col_offset
+#
+# Number specifies how far from the left side of the terminal (in spaces) to
+# begin printing the columns, in case you want to e.g. center them under your
+# text.
+# Example:
+# col_offset="auto" - Default behavior of neofetch
+# col_offset=7      - Leave 7 spaces then print the colors
+col_offset="auto"
+
+# Progress Bars
+
+
+# Bar characters
+#
+# Default:  '-', '='
+# Values:   'string', 'string'
+# Flag:     --bar_char
+#
+# Example:
+# neofetch --bar_char 'elapsed' 'total'
+# neofetch --bar_char '-' '='
+bar_char_elapsed="-"
+bar_char_total="="
+
+# Toggle Bar border
+#
+# Default:  'on'
+# Values:   'on', 'off'
+# Flag:     --bar_border
+bar_border="on"
+
+# Progress bar length in spaces
+# Number of chars long to make the progress bars.
+#
+# Default:  '15'
+# Values:   'num'
+# Flag:     --bar_length
+bar_length=15
+
+# Progress bar colors
+# When set to distro, uses your distro's logo colors.
+#
+# Default:  'distro', 'distro'
+# Values:   'distro', 'num'
+# Flag:     --bar_colors
+#
+# Example:
+# neofetch --bar_colors 3 4
+# neofetch --bar_colors distro 5
+bar_color_elapsed="distro"
+bar_color_total="distro"
+
+
+# Info display
+# Display a bar with the info.
+#
+# Default: 'off'
+# Values:  'bar', 'infobar', 'barinfo', 'off'
+# Flags:   --cpu_display
+#          --memory_display
+#          --battery_display
+#          --disk_display
+#
+# Example:
+# bar:     '[---=======]'
+# infobar: 'info [---=======]'
+# barinfo: '[---=======] info'
+# off:     'info'
+cpu_display="off"
+memory_display="on"
+battery_display="off"
+disk_display="on"
+
+
+# Backend Settings
+
+
+# Image backend.
+#
+# Default:  'ascii'
+# Values:   'ascii', 'caca', 'chafa', 'jp2a', 'iterm2', 'off',
+#           'pot', 'termpix', 'pixterm', 'tycat', 'w3m', 'kitty'
+# Flag:     --backend
+image_backend="ascii"
+
+# Image Source
+#
+# Which image or ascii file to display.
+#
+# Default:  'auto'
+# Values:   'auto', 'ascii', 'wallpaper', '/path/to/img', '/path/to/ascii', '/path/to/dir/'
+#           'command output (neofetch --ascii "$(fortune | cowsay -W 30)")'
+# Flag:     --source
+#
+# NOTE: 'auto' will pick the best image source for whatever image backend is used.
+#       In ascii mode, distro ascii art will be used and in an image mode, your
+#       wallpaper will be used.
+image_source="auto"
+
+
+# Ascii Options
+
+
+# Ascii distro
+# Which distro's ascii art to display.
+#
+# Default: 'auto'
+# Values:  'auto', 'distro_name'
+# Flag:    --ascii_distro
+# NOTE: AIX, Alpine, Anarchy, Android, Antergos, antiX, "AOSC OS",
+#       "AOSC OS/Retro", Apricity, ArcoLinux, ArchBox, ARCHlabs,
+#       ArchStrike, XFerience, ArchMerge, Arch, Artix, Arya, Bedrock,
+#       Bitrig, BlackArch, BLAG, BlankOn, BlueLight, bonsai, BSD,
+#       BunsenLabs, Calculate, Carbs, CentOS, Chakra, ChaletOS,
+#       Chapeau, Chrom*, Cleanjaro, ClearOS, Clear_Linux, Clover,
+#       Condres, Container_Linux, CRUX, Cucumber, Debian, Deepin,
+#       DesaOS, Devuan, DracOS, DarkOs, DragonFly, Drauger, Elementary,
+#       EndeavourOS, Endless, EuroLinux, Exherbo, Fedora, Feren, FreeBSD,
+#       FreeMiNT, Frugalware, Funtoo, GalliumOS, Garuda, Gentoo, Pentoo,
+#       gNewSense, GNOME, GNU, GoboLinux, Grombyang, Guix, Haiku, Huayra,
+#       Hyperbola, janus, Kali, KaOS, KDE_neon, Kibojoe, Kogaion,
+#       Korora, KSLinux, Kubuntu, LEDE, LFS, Linux_Lite,
+#       LMDE, Lubuntu, Lunar, macos, Mageia, MagpieOS, Mandriva,
+#       Manjaro, Maui, Mer, Minix, LinuxMint, MX_Linux, Namib,
+#       Neptune, NetBSD, Netrunner, Nitrux, NixOS, Nurunner,
+#       NuTyX, OBRevenge, OpenBSD, openEuler, OpenIndiana, openmamba,
+#       OpenMandriva, OpenStage, OpenWrt, osmc, Oracle, OS Elbrus, PacBSD,
+#       Parabola, Pardus, Parrot, Parsix, TrueOS, PCLinuxOS, Peppermint,
+#       popos, Porteus, PostMarketOS, Proxmox, Puppy, PureOS, Qubes, Radix,
+#       Raspbian, Reborn_OS, Redstar, Redcore, Redhat, Refracted_Devuan,
+#       Regata, Rosa, sabotage, Sabayon, Sailfish, SalentOS, Scientific,
+#       Septor, SereneLinux, SharkLinux, Siduction, Slackware, SliTaz,
+#       SmartOS, Solus, Source_Mage, Sparky, Star, SteamOS, SunOS,
+#       openSUSE_Leap, openSUSE_Tumbleweed, openSUSE, SwagArch, Tails,
+#       Trisquel, Ubuntu-Budgie, Ubuntu-GNOME, Ubuntu-MATE, Ubuntu-Studio,
+#       Ubuntu, Venom, Void, Obarun, windows10, Windows7, Xubuntu, Zorin,
+#       and IRIX have ascii logos
+# NOTE: Arch, Ubuntu, Redhat, and Dragonfly have 'old' logo variants.
+#       Use '{distro name}_old' to use the old logos.
+# NOTE: Ubuntu has flavor variants.
+#       Change this to Lubuntu, Kubuntu, Xubuntu, Ubuntu-GNOME,
+#       Ubuntu-Studio, Ubuntu-Mate  or Ubuntu-Budgie to use the flavors.
+# NOTE: Arcolinux, Dragonfly, Fedora, Alpine, Arch, Ubuntu,
+#       CRUX, Debian, Gentoo, FreeBSD, Mac, NixOS, OpenBSD, android,
+#       Antrix, CentOS, Cleanjaro, ElementaryOS, GUIX, Hyperbola,
+#       Manjaro, MXLinux, NetBSD, Parabola, POP_OS, PureOS,
+#       Slackware, SunOS, LinuxLite, OpenSUSE, Raspbian,
+#       postmarketOS, and Void have a smaller logo variant.
+#       Use '{distro name}_small' to use the small variants.
+ascii_distro="gentoo_small" # change it to your distro ascii logo but small.
+
+# Ascii Colors
+#
+# Default:  'distro'
+# Values:   'distro', 'num' 'num' 'num' 'num' 'num' 'num'
+# Flag:     --ascii_colors
+#
+# Example:
+# ascii_colors=(distro)      - Ascii is colored based on Distro colors.
+# ascii_colors=(4 6 1 8 8 6) - Ascii is colored using these colors.
+ascii_colors=(distro)
+
+# Bold ascii logo
+# Whether or not to bold the ascii logo.
+#
+# Default: 'on'
+# Values:  'on', 'off'
+# Flag:    --ascii_bold
+ascii_bold="on"
+
+
+# Image Options
+
+
+# Image loop
+# Setting this to on will make neofetch redraw the image constantly until
+# Ctrl+C is pressed. This fixes display issues in some terminal emulators.
+#
+# Default:  'off'
+# Values:   'on', 'off'
+# Flag:     --loop
+image_loop="off"
+
+# Thumbnail directory
+#
+# Default: '~/.cache/thumbnails/neofetch'
+# Values:  'dir'
+thumbnail_dir="${XDG_CACHE_HOME:-${HOME}/.cache}/thumbnails/neofetch"
+
+# Crop mode
+#
+# Default:  'normal'
+# Values:   'normal', 'fit', 'fill'
+# Flag:     --crop_mode
+#
+# See this wiki page to learn about the fit and fill options.
+# https://github.com/dylanaraps/neofetch/wiki/What-is-Waifu-Crop%3F
+crop_mode="normal"
+
+# Crop offset
+# Note: Only affects 'normal' crop mode.
+#
+# Default:  'center'
+# Values:   'northwest', 'north', 'northeast', 'west', 'center'
+#           'east', 'southwest', 'south', 'southeast'
+# Flag:     --crop_offset
+crop_offset="center"
+
+# Image size
+# The image is half the terminal width by default.
+#
+# Default: 'auto'
+# Values:  'auto', '00px', '00%', 'none'
+# Flags:   --image_size
+#          --size
+image_size="auto"
+
+# Gap between image and text
+#
+# Default: '3'
+# Values:  'num', '-num'
+# Flag:    --gap
+gap=3
+
+# Image offsets
+# Only works with the w3m backend.
+#
+# Default: '0'
+# Values:  'px'
+# Flags:   --xoffset
+#          --yoffset
+yoffset=0
+xoffset=0
+
+# Image background color
+# Only works with the w3m backend.
+#
+# Default: ''
+# Values:  'color', 'blue'
+# Flag:    --bg_color
+background_color=
+
+
+# Misc Options
+
+# Stdout mode
+# Turn off all colors and disables image backend (ASCII/Image).
+# Useful for piping into another command.
+# Default: 'off'
+# Values: 'on', 'off'
+stdout="off"

--- a/small/hfetch-nt.conf
+++ b/small/hfetch-nt.conf
@@ -2,7 +2,6 @@
 # https://github.com/dylanaraps/neofetch/wiki/Customizing-Info
 echo " "
 print_info() {
-    info "->" title
     info "-> OS" distro
     info "-> Kernel" kernel
     info "-> Uptime" uptime

--- a/small/hfetch-nt.conf
+++ b/small/hfetch-nt.conf
@@ -199,37 +199,6 @@ disk_subtitle="mount"
 disk_percent="on"
 
 
-# Format to display song information.
-#
-# Default: '%artist% - %album% - %title%'
-# Values:  '%artist%', '%album%', '%title%'
-# Flag:    --song_format
-#
-# Example:
-# default: 'Song: Jet - Get Born - Sgt Major'
-song_format="%artist% - %album% - %title%"
-
-# Print the Artist, Album and Title on separate lines
-#
-# Default: 'off'
-# Values:  'on', 'off'
-# Flag:    --song_shorthand
-#
-# Example:
-# on:  'Artist: The Fratellis'
-#      'Album: Costello Music'
-#      'Song: Chelsea Dagger'
-#
-# off: 'Song: The Fratellis - Costello Music - Chelsea Dagger'
-song_shorthand="off"
-
-# 'mpc' arguments (specify a host, password etc).
-#
-# Default:  ''
-# Example: mpc_args=(-h HOST -P PASSWORD)
-mpc_args=()
-
-
 # Text Colors
 
 

--- a/small/hfetch-nt.conf
+++ b/small/hfetch-nt.conf
@@ -4,33 +4,12 @@ echo " "
 print_info() {
     info "->" title
     info "-> OS" distro
-    #info "Host" model
     info "-> Kernel" kernel
     info "-> Uptime" uptime
-    #info "Packages" packages
     info "-> Shell" shell
-    #info "Resolution" resolution
-    #info "DE" de
-    #info "WM" wm
-    #info "WM Theme" wm_theme
-    #info "Theme" theme
-    #info "Icons" icons
     info "-> Terminal" term
-    #info "Terminal Font" term_font
-    #info "CPU" cpu
-    #info "GPU" gpu
     info "-> Memory" memory
-
-    # info "GPU Driver" gpu_driver  # Linux/macOS only
-    # info "CPU Usage" cpu_usage
     info "-> Disk" disk
-    # info "Battery" battery
-    # info "Font" font
-    # info "Song" song
-    # [[ "$player" ]] && prin "Music Player" "$player"
-    # info "Local IP" local_ip
-    # info "Public IP" public_ip
-    # info "Users" users
     info "-> Locale" locale  # This only works on glibc systems.
 
     info cols


### PR DESCRIPTION
hfetch-nt is designed to be a bit like my fetch (aka [hfetch](https://github.com/gentoo-btw/hfetch)) 
and hfetch-nt is a little bit smaller than hfetch. it has the hostname/user removed.
still the colorblocks and everything else (expect the colors and logo) looks like hfetch.

preview:
![image](https://user-images.githubusercontent.com/119129086/205440526-919adb1e-5da0-4de8-8385-b165193d9d43.png)
