### PR TITLE
docs(cli): better command to switch themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ in your preferred folder.
 
 3. Run 
 ```bash
-cat neofetch-themes/<folder>/<file> >> ~/.config/neofetch/config.conf
+cat neofetch-themes/<folder>/<file> > ~/.config/neofetch/config.conf
 ```
 where `<folder>` is the section in this readme, while `<file>` is the file name of the config of this theme.
 > For example: If you want papirus, it'd be
 ```
-cat neofetch-themes/normal/papirus.conf >> ~/.config/neofetch/config.conf
+cat neofetch-themes/normal/papirus.conf > ~/.config/neofetch/config.conf
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ in your preferred folder.
 
 3. Run 
 ```bash
-mv neofetch-themes/<folder>/<file> ~/.config/neofetch/config.conf
+cat neofetch-themes/<folder>/<file> >> ~/.config/neofetch/config.conf
 ```
 where `<folder>` is the section in this readme, while `<file>` is the file name of the config of this theme.
 > For example: If you want papirus, it'd be
 ```
-mv neofetch-themes/normal/papirus.conf ~/.config/neofetch/config.conf
+cat neofetch-themes/normal/papirus.conf >> ~/.config/neofetch/config.conf
 ```
 
 </details>


### PR DESCRIPTION
Since the `mv` command will move the theme file, the user won't be able to switch back from the chosen theme. Instead, reading the file with `cat` and writing to the existing configuration is more practical.

Changed:
```bash
mv neofetch-themes/<folder>/<file> ~/.config/neofetch/config.conf
```

to:
```bash
cat neofetch-themes/<folder>/<file> > ~/.config/neofetch/config.conf
```