### PR TITLE
Updating Material Design Icons

### DIFF
--- a/normal/acenoster.conf
+++ b/normal/acenoster.conf
@@ -10,25 +10,25 @@ print_info() {
     info "${cl2} ╭─" distro
     info "${cl2} ├─" kernel
 	info "${cl2} ├─" users
-    info "${cl2} ├─" packages
+    info "${cl2} ├─󰏗" packages
     info "${cl2} ╰─" shell
     echo
     info "${cl6} ╭─" de
     info "${cl6} ├─" term
 	info "${cl6} ├─" term_font
-	info "${cl6} ├─" theme
-	info "${cl6} ├─" icons
+	info "${cl6} ├─󰂫" theme
+	info "${cl6} ├─󰂫" icons
 	info "${cl6} ╰─" font
     echo
     info "${cl4} ╭─" model
-    info "${cl4} ├─" cpu
-    info "${cl4} ├─" gpu
+    info "${cl4} ├─󰍛" cpu
+    info "${cl4} ├─󰍹" gpu
 #	info "${cl4} ├─" gpu_driver
     info "${cl4} ├─" resolution
     info "${cl4} ├─" memory
 	info "${cl4} ├─ ${cl0}" disk
-#	info "${cl4} ├─ ${cl0} " battery 
-    info "${cl4} ╰─" uptime
+#	info "${cl4} ├─󰁹 ${cl0} " battery 
+    info "${cl4} ╰─󰄉" uptime
     
 	prin " "
 	prin " \n \n \n \n \n \n ${cl3} \n \n ${cl5} \n \n ${cl2}  \n \n ${cl6}  \n \n ${cl4}  \n \n ${cl1}  \n \n ${cl7}  \n \n ${cl0}  \n \n "

--- a/normal/acenoster.conf
+++ b/normal/acenoster.conf
@@ -530,7 +530,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char=""
+underline_char="󰍴"
 
 # Info Separator
 # Replace the default separator with the specified string.

--- a/normal/bejkon/config.conf
+++ b/normal/bejkon/config.conf
@@ -13,27 +13,27 @@ print_info() {
     info "\n \n " model
     info "\n \n " kernel
     info "\n \n " uptime
-    info "\n \n " packages
+    info "\n \n 󰏗" packages
     info "\n \n " shell
     # info "\n \n " resolution
     # info "\n \n " de
     # info "\n \n " wm
-    # info "\n \n 嗀"wm_theme
-    info "\n \n 嗀"theme
+    # info "\n \n 󰔎"wm_theme
+    info "\n \n 󰔎"theme
     # info "\n \n " icons
     info "\n \n " term
     info "\n \n " term_font
     info "\n \n " cpu
-    info "\n \n " gpu
+    info "\n \n 󰊚" gpu
     info "\n \n " memory
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage
     info "\n \n " disk
-    # info "\n \n " battery
+    # info "\n \n 󰂄" battery
     # info "\n \n " font
     info "\n \n " song
     [[ "$player" ]] && prin "\n \n " "$player"
-    info "\n \n " local_ip
+    info "\n \n 󰈀" local_ip
     # info "Public IP" public_ip 
     prin "${cl9}└───────────────────── ${cl0} ${cl1} ${cl2} ${cl3} ${cl4} ${cl5} ${cl6} $(color 15) ${cl9}┘"
     # info "Users" users

--- a/normal/config.conf
+++ b/normal/config.conf
@@ -8,12 +8,12 @@
 
 print_info() {
     prin "┌─────────\n Hardware Information \n─────────┐"
-    info " ​ ​  " model
-    info " ​ ​  " cpu
-    info " ​ ​ ﬙ " gpu
+    info " ​ ​ 󰌢 " model
+    info " ​ ​ 󰍛 " cpu
+    info " ​ ​ 󰘚 " gpu
 #    info " ​ ​  " disk
-    info " ​ ​ 塞" memory
-    info " ​ ​  " resolution
+    info " ​ ​ 󰑭" memory
+    info " ​ ​ 󰍹 " resolution
 #    info " ​ ​ 󱈑 " battery 
     prin "├─────────\n Software Information \n─────────┤"
 #    info " ​ ​  " users
@@ -26,13 +26,13 @@ print_info() {
     info " ​ ​  " term
     info " ​ ​  " term_font
 #    info " ​ ​ │  " font
-#    info " ​ ​   " theme
-#    info " ​ ​   " icons
-    info " ​ ​  " packages 
+#    info " ​ ​  󰉼 " theme
+#    info " ​ ​  󰀻 " icons
+    info " ​ ​ 󰊠 " packages 
 #    info " ​ ​  󰅐 " uptime
 #    info " ​ ​   " gpu_driver  # Linux/macOS only
 #    info " ​ ​  " cpu_usage
-#    info " ​ ​ ﱘ " song
+#    info " ​ ​ 󰝚 " song
     # [[ "$player" ]] && prin "Music Player" "$player"
 #    info " ​ ​   " local_ip
 #    info " ​ ​   " public_ip

--- a/normal/config2.conf
+++ b/normal/config2.conf
@@ -12,12 +12,12 @@ print_info() {
 #    info underline
     prin ""
     prin "Hardware Information"
-    info " " model
-    info " " cpu
-    info "﬙ " gpu
+    info "󰌢 " model
+    info "󰍛 " cpu
+    info "󰘚 " gpu
 #    info " " disk
-    info "ﳔ " memory
-    info " " resolution
+    info "󰟖 " memory
+    info "󰍹 " resolution
 #    info "󱈑 " battery 
 #    info underline
     prin ""
@@ -30,9 +30,9 @@ print_info() {
 #    info "Shell" shell
     info " " term
     info " " term_font
-#    info " " theme
-#    info " " icons
-    info " " packages
+#    info "󰉼 " theme
+#    info "󰀻 " icons
+    info "󰊠 " packages
 #    info "󰅐 " uptime
 	# Backup
     # info "GPU Driver" gpu_driver  # Linux/macOS only

--- a/normal/hybridfetch.conf
+++ b/normal/hybridfetch.conf
@@ -10,12 +10,12 @@
 # https://github.com/dylanaraps/neofetch/wiki/Customizing-Info
 print_info() {
     prin "┌─────────\n Hardware Information \n─────────┐"
-    info " ​ ​  " model
-    info " ​ ​  " cpu
-    info " ​ ​ ﬙ " gpu
+    info " ​ ​ 󰌢 " model
+    info " ​ ​ 󰍛 " cpu
+    info " ​ ​ 󰘚 " gpu
 #    info " ​ ​  " disk
     info " ​ ​  " memory
-    info " ​ ​  " resolution
+    info " ​ ​ 󰍹 " resolution
 #    info " ​ ​ 󱈑 " battery 
     prin "├─────────\n Software Information \n─────────┤"
 #    info " ​ ​  " users
@@ -28,13 +28,13 @@ print_info() {
     info " ​ ​  " term
 #    info " ​ ​  " term_font
 #    info " ​ ​ │  " font
-#    info " ​ ​   " theme
-#    info " ​ ​   " icons
-#    info " ​ ​  " packages 
-    info " ​ ​   " uptime
+#    info " ​ ​  󰉼 " theme
+#    info " ​ ​  󰀻 " icons
+#    info " ​ ​ 󰊠 " packages 
+    info " ​ ​  󰊠 " uptime
 #    info " ​ ​   " gpu_driver  # Linux/macOS only
 #    info " ​ ​  " cpu_usage
-#    info " ​ ​ ﱘ " song
+#    info " ​ ​ 󰝚 " song
     # [[ "$player" ]] && prin "Music Player" "$player"
 #    info " ​ ​   " local_ip
 #    info " ​ ​   " public_ip

--- a/normal/idlifetch.conf
+++ b/normal/idlifetch.conf
@@ -11,7 +11,7 @@ print_info() {
     info " ​ ​  " wm
     info " ​ ​  " shell
     info " ​ ​  " term
-    info " ​ ​ 神" uptime
+    info " ​ ​ 󰔚" uptime
 	info " ​ ​  " packages
     prin "$(color 7)└───────────────────────────────┘"
     prin " \n \n $(color 1) \n \n $(color 2) \n \n $(color 3) \n \n $(color 4)  \n \n $(color 5)  \n \n $(color 6)  \n \n $(color 7)  \n \n $(color 0)"

--- a/normal/kenielf/config.conf
+++ b/normal/kenielf/config.conf
@@ -8,10 +8,10 @@ print_info() {
 
     info "$(color 6) OS " distro
     info "$(color 6) VER" kernel
-    info "$(color 6) PKG" packages
-    info "$(color 6) UP " uptime
+    info "$(color 6)󰏗 PKG" packages
+    info "$(color 6)󰥔 UP " uptime
     info underline
-    info "$(color 6)类WM " wm
+    info "$(color 6)󰖯WM " wm
     info "$(color 6) THM" theme
     info "$(color 6) ICO" icons
     info underline

--- a/normal/ozozPredatorFetch.conf
+++ b/normal/ozozPredatorFetch.conf
@@ -13,23 +13,23 @@ print_info() {
     info "${c1} OS" os
     info "${c1}│ ├ " distro
     info "${c1}│ ├ " kernel
-    info "${c1}│ ├ " packages
+    info "${c1}│ ├󰏗 " packages
     info "${c1}│ └ " shell
     
     prin"│"
     
     info "${c2} DE/WM" wm
-    info "${c2}│ ├ " theme
-    info "${c2}│ ├ " icons
+    info "${c2}│ ├󰂫 " theme
+    info "${c2}│ ├󰂫 " icons
     info "${c2}│ └ " term
 
     prin"│"
     
     info "${c3} PC" model
-    info "${c3}│ ├ " cpu
-    info "${c3}│ ├ " gpu
+    info "${c3}│ ├󰍛 " cpu
+    info "${c3}│ ├󰍹 " gpu
     info "${c3}│ ├ " memory
-    info "${c3}│ ├ " uptime
+    info "${c3}│ ├󰅐 " uptime
     info "${c3}│ └ " resolution
     prin "$(color 1)└─────────────────────────────────────────────────┘"
 

--- a/normal/ozozPredatorFetch.conf
+++ b/normal/ozozPredatorFetch.conf
@@ -535,7 +535,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char=""
+underline_char="󰍴"
 
 # Info Separator
 # Replace the default separator with the specified string.

--- a/normal/ozozfetch
+++ b/normal/ozozfetch
@@ -12,19 +12,19 @@ print_info() {
     info "${c1} OS" os
     info "${c1} ├ " distro
     info "${c1} ├ " kernel
-    info "${c1} ├ " packages
+    info "${c1} ├󰏗 " packages
     info "${c1} └ " shell
     echo
     info "${c2} DE/WM" wm
-    info "${c2} ├ " theme
-    info "${c2} ├ " icons
+    info "${c2} ├󰂫 " theme
+    info "${c2} ├󰂫 " icons
     info "${c2} └ " term
     echo
     info "${c3} PC" model
-    info "${c3} ├ " cpu
-    info "${c3} ├ " gpu
+    info "${c3} ├󰍛 " cpu
+    info "${c3} ├󰍹 " gpu
     info "${c3} ├ " memory
-    info "${c3} ├ " uptime
+    info "${c3} ├󰅐 " uptime
     info "${c3} └ " resolution
     
     info cols

--- a/normal/ozozfetch
+++ b/normal/ozozfetch
@@ -526,7 +526,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char=""
+underline_char="󰍴"
 
 # Info Separator
 # Replace the default separator with the specified string.

--- a/normal/ozozfetch.conf
+++ b/normal/ozozfetch.conf
@@ -12,19 +12,19 @@ print_info() {
     info "${c1} OS" os
     info "${c1} ├ " distro
     info "${c1} ├ " kernel
-    info "${c1} ├ " packages
+    info "${c1} ├󰏗 " packages
     info "${c1} └ " shell
     echo
     info "${c2} DE/WM" wm
-    info "${c2} ├ " theme
-    info "${c2} ├ " icons
+    info "${c2} ├󰂫 " theme
+    info "${c2} ├󰂫 " icons
     info "${c2} └ " term
     echo
     info "${c3} PC" model
-    info "${c3} ├ " cpu
-    info "${c3} ├ " gpu
+    info "${c3} ├󰍛 " cpu
+    info "${c3} ├󰍹 " gpu
     info "${c3} ├ " memory
-    info "${c3} ├ " uptime
+    info "${c3} ├󰅐 " uptime
     info "${c3} └ " resolution
     
     info cols

--- a/normal/ozozfetch.conf
+++ b/normal/ozozfetch.conf
@@ -526,7 +526,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char=""
+underline_char="󰍴"
 
 # Info Separator
 # Replace the default separator with the specified string.

--- a/normal/remfetch/config.conf
+++ b/normal/remfetch/config.conf
@@ -17,10 +17,10 @@ print_info() {
     info "⊞ " wm
     #info "WM Theme" wm_theme
     info " " theme
-    #info "" icons
+    #info "󰍮" icons
     #info " " "Ryzen 5 3600"
     #info " " gpu
-    #info " " memory
+    #info "󰍛 " memory
 
     # info "GPU Driver" gpu_driver  # Linux/macOS only
     # info "CPU Usage" cpu_usage

--- a/normal/troutfetch.conf
+++ b/normal/troutfetch.conf
@@ -12,14 +12,14 @@ print_info() {
     info "​ ​ ​  >" kernel
     info "​ ​ ​  >" packages
     prin "$(color 7)​ Hardware"
-    info "​ ​​ ​  >" cpu
+    info "​ ​​ ​ 󰍛 >" cpu
     info "​ ​​ ​  >" gpu
-    info "​ ​​ ​ 塞>" memory
-    info "​ ​​ ​  >" resolution
+    info "​ ​​ ​ 󰑭>" memory
+    info "​ ​​ ​ 󰍹 >" resolution
     prin "$(color 7)​ ETC"
-    info "​ ​​ ​ ﱘ >" song
+    info "​ ​​ ​ 󰝚 >" song
     # extra etcs you can use
-    # info "​ ​​ ​  >" disk
+    # info "​ ​​ ​ 󰋊 >" disk
     # info "​ ​​ ​  >" local_ip # or public_ip if you're edgy
     prin "$(color 7)└───────────────────────────────┘"
 

--- a/small/af++/config.conf
+++ b/small/af++/config.conf
@@ -7,7 +7,7 @@ print_info() {
     info "\e[34m " packages
     info "\e[35m " wm
     info "\e[32m " shell
-    #info "\e[33m塞" memory
+    #info "\e[33m󰑭" memory
 }
 
 # Shorten the output of the kernel function.

--- a/small/axylfetch.conf
+++ b/small/axylfetch.conf
@@ -16,7 +16,7 @@ print_info() {
     #info "Kernel" kernel
     #info "Uptime" uptime
     prin "\e[33m " $(cat /proc/1/comm)
-    info "\e[32m " packages
+    info "\e[32m󰏗 " packages
     #info "Resolution" resolution
     #info "DE" de
     info "\e[34m " wm

--- a/small/dotfetch.conf
+++ b/small/dotfetch.conf
@@ -5,11 +5,11 @@ print_info() {
     prin " "
     info "$(color 1) OS  " distro
     info "$(color 2) VER" kernel
-    info "$(color 3) UP " uptime
-    info "$(color 4) PKG" packages
+    info "$(color 3)󰥔 UP " uptime
+    info "$(color 4)󰏗 PKG" packages
     prin "$(color 5) CPU:	$(color fg)Intel i7-6500U (4) @ 3.100GHz" # Hardcoded for fast startup
     prin "$(color 6) GPU:	$(color fg)AMD ATI Radeon HD 8670A" # Hardcoded for fast startup
-    info "$(color 7) MEM" memory
+    info "$(color 7)󰍛 MEM" memory
     prin "$(color 1) $(color 2) $(color 3) $(color 4) $(color 5) $(color 6) $(color 7) $(color 8)"
 }
 

--- a/small/ozozfetch.conf
+++ b/small/ozozfetch.conf
@@ -514,7 +514,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char=""
+underline_char="󰍴"
 
 # Info Separator
 # Replace the default separator with the specified string.

--- a/small/ozozfetch.conf
+++ b/small/ozozfetch.conf
@@ -11,9 +11,9 @@ print_info() {
     info "${c5} ├─  Distro     " distro
     info "${c5} ├─  Kernel     " kernel
     info "${c5} ├─  DE/WM      " wm
-    info "${c5} ├─  CPU        " cpu
-    info "${c5} ├─  GPU        " gpu
-    info "${c5} ├─  Up Time    " uptime
+    info "${c5} ├─ 󰍛 CPU        " cpu
+    info "${c5} ├─ 󰍹 GPU        " gpu
+    info "${c5} ├─ 󰅐 Up Time    " uptime
     info "${c5} └─  SHELL      " shell 
     prin "$(color 1)  $(color 2) $(color 3) $(color 4) $(color 5) $(color 6) $(color 7) $(color 8)"
     

--- a/small/ozozfetch2.conf
+++ b/small/ozozfetch2.conf
@@ -12,9 +12,9 @@ print_info() {
     info "${c5} ├─  Distro     " distro
     info "${c5} ├─  Kernel     " kernel
     info "${c5} ├─  DE/WM      " wm
-    info "${c5} ├─  CPU        " cpu
-    info "${c5} ├─  GPU        " gpu
-    info "${c5} ├─  Up Time    " uptime
+    info "${c5} ├─ 󰍛 CPU        " cpu
+    info "${c5} ├─ 󰍹 GPU        " gpu
+    info "${c5} ├─ 󰅐 Up Time    " uptime
     info "${c5} ├─  SHELL      " shell 
     prin "$(color 9) └────$(color 10)────$(color 11)────$(color 12)────$(color 13)────$(color 14)────$(color 15)────$(color 16)──"
     

--- a/small/ozozfetch2.conf
+++ b/small/ozozfetch2.conf
@@ -515,7 +515,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char=""
+underline_char="󰍴"
 
 # Info Separator
 # Replace the default separator with the specified string.

--- a/small/penguinfetch.conf
+++ b/small/penguinfetch.conf
@@ -7,15 +7,15 @@ print_info() {
     info title
     info underline
 
-    info "${cl1} " distro
+    info "${cl1}󰍹 " distro
 #    info "${cl4}Host" model
-    info "${cl3}ﲶ " kernel
+    info "${cl3}󰞸 " kernel
 #    info "Uptime" uptime
     info "${cl2} " packages
     info "${cl5} " shell
 #    info "Resolution" resolution
 #    info "DE" de
-    info "${cl6}类" wm
+    info "${cl6}󰖯" wm
 #    info "WM Theme" wm_theme
 #    info "Theme" theme
 #    info "Icons" icons

--- a/small/simplefetch.conf
+++ b/small/simplefetch.conf
@@ -8,7 +8,7 @@ print_info() {
     info "$(color 3) " shell
     info "$(color 15) " term
     info "$(color 13) " wm
-    info "$(color 14) " resolution
+    info "$(color 14)󰍹 " resolution
     info cols
 }
 


### PR DESCRIPTION
This PR updates the Material Design Icons in accordance with the latest changes mentioned on the Nerd Fonts website. "With Release v3.0.0 the Material Design Icons were updated and moved to new codepoints (reasons for that are in the release notes)."
This PR also resolves #45