### PR TITLE
Fixed ozozFetch

### DIFF
--- a/normal/ozozfetch
+++ b/normal/ozozfetch
@@ -12,7 +12,7 @@ print_info() {
     info "${c1} OS" os
     info "${c1} ├ " distro
     info "${c1} ├ " kernel
-    info "${c1} ├󰏗 " packages
+    info "${c1} ├󰏗 " packages  
     info "${c1} └ " shell
     echo
     info "${c2} DE/WM" wm
@@ -21,10 +21,10 @@ print_info() {
     info "${c2} └ " term
     echo
     info "${c3} PC" model
-    info "${c3} ├󰍛 " cpu
+    info "${c3} ├󰍛 " cpu 
     info "${c3} ├󰍹 " gpu
     info "${c3} ├ " memory
-    info "${c3} ├󰅐 " uptime
+    info "${c3} ├ " uptime
     info "${c3} └ " resolution
     
     info cols
@@ -526,7 +526,7 @@ underline_enabled="on"
 # Default:  '-'
 # Values:   'string'
 # Flag:     --underline_char
-underline_char="󰍴"
+underline_char=""
 
 # Info Separator
 # Replace the default separator with the specified string.


### PR DESCRIPTION
Many of the icons were displaying as empty boxes because: 

https://www.nerdfonts.com/cheat-sheet
With Release v3.0.0 the Material Design Icons were updated and moved to new codepoints (reasons for that are in the release notes).
They are still shown here for reference, but are missing in the actual fonts.
To find for example the replacement for nf-mdi-altimeter enter just altimeter in the search box.

I updated them to the new codepoint. For example f85a became f035b.

This is mentioned in these issues
https://github.com/Chick2D/neofetch-themes/issues/54
https://github.com/Chick2D/neofetch-themes/issues/55